### PR TITLE
feat: Add macOS Silicon build scripts for sgg library and demo.

### DIFF
--- a/build_demo_macOS_Silicon.sh
+++ b/build_demo_macOS_Silicon.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# @dmarakom6 modifications of @gsiros's shell script build_demo_macOS.sh for Silicon Macs
+
+# Install dependencies if missing
+echo "Checking dependencies..."
+brew install glew sdl2 sdl2_mixer freetype
+
+
+CC=g++
+LD=g++
+BUILD_PATH="build/Release"
+BUILD_PATH_DEBUG="build/Debug"
+BIN_PATH="bin"
+LIB_PATH="lib"
+CFLAGS="-O2 -arch x86_64"
+CFLAGS_DEBUG="-Og -g -arch x86_64"
+
+mkdir -p build
+mkdir -p $BIN_PATH
+mkdir -p $BIN_PATH/assets
+mkdir -p $BUILD_PATH
+mkdir -p $BUILD_PATH_DEBUG
+
+compile_demo() {
+    local target_name=$1
+    local cflags=$2
+    local sgg_lib=$3
+    local build_path=$4
+    echo "Compiling $target_name..."
+    $CC -std=c++17 $cflags -L$LIB_PATH -L$GLEW_LIB_PATH -I. demo/demo.cpp -o $BIN_PATH/$target_name -l$sgg_lib -lGLEW -lSDL2 -lSDL2_mixer -lfreetype -framework OpenGL
+}
+
+GLEW_LIB_PATH="$(brew --prefix)/opt/glew/lib"
+
+compile_demo demo "$CFLAGS" sgg "$BUILD_PATH"
+compile_demo demod "$CFLAGS_DEBUG" sggd "$BUILD_PATH_DEBUG"
+
+cp -r 3rdparty/assets $BIN_PATH
+
+

--- a/build_sgg_macOS_Silicon.sh
+++ b/build_sgg_macOS_Silicon.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# @dmarakom6 modifications of @gsiros's shell script build_sgg_macOS.sh for Silicon Macs
+
+# Install dependencies if missing
+echo "Checking dependencies..."
+brew install glew sdl2 sdl2_mixer freetype
+
+CC=g++
+LD=g++
+AR=ar
+BUILD_PATH="build/Release"
+BUILD_PATH_DEBUG="build/Debug"
+LIB_PATH="lib"
+CFLAGS="-O2 -arch x86_64"
+CFLAGS_DEBUG="-Og -g -arch x86_64"
+
+mkdir -p build
+mkdir -p $LIB_PATH
+mkdir -p $BUILD_PATH
+mkdir -p $BUILD_PATH_DEBUG
+mkdir -p $BUILD_PATH/sgg
+mkdir -p $BUILD_PATH_DEBUG/sgg
+
+echo "-- START OF SGG LIB (RELEASE) COMPILATION --"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/graphics.cpp -o $BUILD_PATH/sgg/graphics.o
+echo "Compiled graphics!"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/GLbackend.cpp -o $BUILD_PATH/sgg/GLbackend.o
+echo "Compiled GLbackend!"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/shader.cpp -o $BUILD_PATH/sgg/shader.o
+echo "Compiled shader!"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/texture.cpp -o $BUILD_PATH/sgg/texture.o
+echo "Compiled texture!"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/audio.cpp -o $BUILD_PATH/sgg/audio.o
+echo "Compiled audio!"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/AudioManager.cpp -o $BUILD_PATH/sgg/AudioManager.o
+echo "Compiled AudioManager!"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/lodepng.cpp -o $BUILD_PATH/sgg/lodepng.o
+echo "Compiled lodepng!"
+$CC -c -std=c++17 $CFLAGS -I. -I3rdparty/include sgg/fonts.cpp -o $BUILD_PATH/sgg/fonts.o
+echo "Compiled fonts!"
+
+$AR rcs $LIB_PATH/libsgg.a $BUILD_PATH/sgg/*.o
+
+echo "-- START OF SGG LIB (DEBUG) COMPILATION --"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/graphics.cpp -o $BUILD_PATH_DEBUG/sgg/graphics.o
+echo "Compiled graphics!"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/GLbackend.cpp -o $BUILD_PATH_DEBUG/sgg/GLbackend.o
+echo "Compiled GLbackend!"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/shader.cpp -o $BUILD_PATH_DEBUG/sgg/shader.o
+echo "Compiled shader!"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/texture.cpp -o $BUILD_PATH_DEBUG/sgg/texture.o
+echo "Compiled texture!"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/audio.cpp -o $BUILD_PATH_DEBUG/sgg/audio.o
+echo "Compiled audio!"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/AudioManager.cpp -o $BUILD_PATH_DEBUG/sgg/AudioManager.o
+echo "Compiled AudioManager!"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/lodepng.cpp -o $BUILD_PATH_DEBUG/sgg/lodepng.o
+echo "Compiled lodepng!"
+$CC -c -std=c++17 $CFLAGS_DEBUG -I. -I3rdparty/include sgg/fonts.cpp -o $BUILD_PATH_DEBUG/sgg/fonts.o
+echo "Compiled fonts!"
+
+$AR rcs $LIB_PATH/libsggd.a $BUILD_PATH_DEBUG/sgg/*.o


### PR DESCRIPTION
### Fix Build on Apple Silicon Macs

This PR addresses build issues on Apple Silicon Macs by:
1.  Targeting `x86_64` architecture (Rosetta 2) to ensure compatibility with Homebrew libraries (`glew`, `sdl2`, etc.) which are installed as x86_64 binaries in `/usr/local` on Intel/Rosetta setups or `/opt/homebrew` on native Silicon setups (though these specific libraries were causing issues due to arch mismatch).
2.  Adding automatic dependency checks and installation via Homebrew in the build scripts.
3.  Providing specific scripts `build_sgg_macOS_Silicon.sh` and `build_demo_macOS_Silicon.sh` for Silicon users that handle these configurations automatically, so there is no need to use a VM anymore.
<img width="1625" height="1108" alt="image" src="https://github.com/user-attachments/assets/c01f43fc-039c-481b-87de-738bbe9bc45a" />


